### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ This project is part of the Model Context Protocol (MCP) initiative from Anthrop
 > [!NOTE]
 > AI Generated Code. I used Cline v2.2.2 with Claude 3.5 Sonnet (2024-10-22). See docs/README.md for prompts and details about how this code was generated.
 
+<a href="https://glama.ai/mcp/servers/zoig549xfd"><img width="380" height="200" src="https://glama.ai/mcp/servers/zoig549xfd/badge" alt="postman-mcp-server MCP server" /></a>
+
 ---
 
 * [Overview](#overview)


### PR DESCRIPTION
This PR adds a badge for the postman-mcp-server server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/zoig549xfd"><img width="380" height="200" src="https://glama.ai/mcp/servers/zoig549xfd/badge" alt="postman-mcp-server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.